### PR TITLE
Also install lua.hpp for Lua 5.1.x

### DIFF
--- a/etc/winmake.bat
+++ b/etc/winmake.bat
@@ -185,7 +185,7 @@ if %LUA_SVER%==51 (
    set FILES_LIB=lbaselib ldblib liolib lmathlib loslib ltablib lstrlib loadlib linit
    set FILES_DLL=lua 
    set FILES_OTH=luac print
-   set INSTALL_H=lauxlib.h lua.h luaconf.h lualib.h
+   set INSTALL_H=lauxlib.h lua.h luaconf.h lualib.h ..\etc\lua.hpp
 )
 if %LUA_SVER%==52 (
    set FILES_CORE=lapi lcode lctype ldebug ldo ldump lfunc lgc llex lmem lobject lopcodes lparser lstate lstring ltable ltm lundump lvm lzio lauxlib


### PR DESCRIPTION
Since we are copying files from src, the resulting path will be <some_dir>\src..\etc\lua.hpp, which is effectively, <some_dir>\etc\lua.hpp

See #2
