### PR TITLE
Adds support for VS 2017 and mingw-w64

### DIFF
--- a/.appveyor/set_compiler_env.bat
+++ b/.appveyor/set_compiler_env.bat
@@ -3,13 +3,17 @@
 :: Now we declare a scope
 Setlocal EnableDelayedExpansion EnableExtensions
 
-if not defined Configuration set Configuration=2015
+if not defined Configuration set Configuration=2017
 
 if "%Configuration%"=="MinGW" ( goto :mingw )
 
 set arch=x86
 
 if "%platform%" EQU "x64" ( set arch=x86_amd64 )
+
+if "%Configuration%"=="2017" (
+	set SET_VS_ENV="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat"
+)
 
 if "%Configuration%"=="2015" (
 	set SET_VS_ENV="C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
@@ -37,4 +41,4 @@ goto :eof
 
 :: MinGW detected
 :mingw
-endlocal & set PATH=c:\mingw\bin;%PATH%
+endlocal & set PATH=C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ version: 0.0.1.{build}-test
 
 shallow_clone: true
 
+image: Visual Studio 2017
+
 environment:
   matrix:
   - LUA_VER: 5.1.5
@@ -15,6 +17,7 @@ environment:
 # Abuse this section so we can have a matrix with different Compiler versions
 # Is there a better way? Like injecting an array in the matrix?
 configuration:
+ - 2017
  - 2015
  - 2013
  - 2012


### PR DESCRIPTION
Adds Visual Studio 2017 to the compilation matrix.
Starts using mingw-w64 7.3.0 x86_64 instead of MinGW 32-bit 5.3.0