### PR TITLE
fix: add Lua 5.4.7 to the ci matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,12 +9,12 @@ environment:
   - LUA_VER: 5.1.5
   - LUA_VER: 5.2.4
   - LUA_VER: 5.3.6
-  - LUA_VER: 5.4.6
+  - LUA_VER: 5.4.7
   - LUA_VER: 5.2.4
     NOCOMPAT: true
   - LUA_VER: 5.3.6
     NOCOMPAT: true
-  - LUA_VER: 5.4.6
+  - LUA_VER: 5.4.7
     NOCOMPAT: true
 
 # Abuse this section so we can have a matrix with different Compiler versions


### PR DESCRIPTION
The macros in lua.h have changed, so detection no longer worked. This change now properly detects 5.4.7 as a 5.4 series release.